### PR TITLE
Fix CSS for image so that it shows up consistently

### DIFF
--- a/components/layout.js
+++ b/components/layout.js
@@ -1,16 +1,12 @@
-import Image from 'next/image'
-import styles from './layout.module.css'
-import utilStyles from '../styles/utils.module.css'
-import Link from 'next/link'
-import Header from './header'
+import Header from "./header"
 
-export const siteTitle = 'Weather'
+export const siteTitle = "Weather"
 
 export default function Layout({ children }) {
   return (
     <div id="main">
-      <div class="backgroundSunnyBlur">
-        <div class="backgroundSunny">
+      <div className="backgroundSunnyBlur">
+        <div className="backgroundSunny">
           <div id="content">
             <Header></Header>
             <main>{children}</main>

--- a/styles/global.css
+++ b/styles/global.css
@@ -2,8 +2,8 @@ html,
 body {
   padding: 0;
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu,
-    Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
+    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
   line-height: 1.6;
   font-size: 18px;
 }
@@ -26,27 +26,20 @@ img {
   display: block;
 }
 
+.backgroundSunnyBlur,
 .backgroundSunny {
-  background:red;
+  background: url("../public/images/warmNight.jpg");
   width: 100vw;
   height: 100vh;
-  background: url('../public/images/warmNight.jpg');
-  width: 100vw;
-  height: 100vh;
-  background-repeat:no-repeat;
-  background-size:contain;
-  background-position:center;
-  backdrop-filter: blur(10px);
+  background-repeat: no-repeat;
+  background-position: center;
 }
 
 .backgroundSunnyBlur {
-  background:red;
-  width: 100vw;
-  height: 100vh;
-  background: url('../public/images/warmNight.jpg');
-  width: 100vw;
-  height: 100vh;
-  background-repeat:no-repeat;
-  background-size:cover;
-  background-position:center;
+  background-size: cover;
+  backdrop-filter: blur(10px);
+}
+
+.backgroundSunny {
+  background-size: contain;
 }


### PR DESCRIPTION
Previously, the background image would show up differently depending
on whether you were using the dev compilation or the prod compilation.

- dev: `npm run dev`
- prod `npm run build && npm start -p 3000`

There were a couple issues to fix here.

1. Rearrange the CSS in the global.css file. There were a few repeated styles,
 so I removed them (height, width, background all in twice). Also,
   the backgroundsunnyblur was later in the cascade, so it was taking
   precedence over the non-blur styles (I think this was causing the bug).
   Finally, consolidated the styles so that we are sharing them intentionally.

2. Use `className` instead of `class`. For some or other reason, JSX
   doesn't like the `class` attribute so changed them to say `className`.
   We were getting this as a warning when starting up the app but no longer.

3. Removed some unneeded imports.